### PR TITLE
build: update LWK to 0.18.0

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ jobs:
           uses: ./.github/actions/setup
 
         - name: Setup rust toolchain
-          uses: dtolnay/rust-toolchain@1.81.0
+          uses: dtolnay/rust-toolchain@1.85.0
           with:
             targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
         
@@ -42,7 +42,7 @@ jobs:
           uses: ./.github/actions/setup
 
         - name: Setup rust toolchain
-          uses: dtolnay/rust-toolchain@1.81.0
+          uses: dtolnay/rust-toolchain@1.85.0
           with:
             targets: x86_64-apple-ios,aarch64-apple-ios,aarch64-apple-ios-sim
         

--- a/fetch_artifacts.sh
+++ b/fetch_artifacts.sh
@@ -3,7 +3,7 @@
 # Manually fetch and edit lwk repository
 
 REPO=https://github.com/Blockstream/lwk-rn
-TAG=0.9.0-2.0
+TAG=0.18.0-2.0
 
 ANDROID_URL=$REPO/releases/download/$TAG/lwk-android-artifact.zip
 curl -L $ANDROID_URL --output lwk-android-artifact.zip

--- a/fetch_artifacts.sh
+++ b/fetch_artifacts.sh
@@ -3,7 +3,7 @@
 # Manually fetch and edit lwk repository
 
 REPO=https://github.com/Blockstream/lwk-rn
-TAG=0.18.0-2.0
+TAG=0.18.0
 
 ANDROID_URL=$REPO/releases/download/$TAG/lwk-android-artifact.zip
 curl -L $ANDROID_URL --output lwk-android-artifact.zip

--- a/fetch_lwk.sh
+++ b/fetch_lwk.sh
@@ -3,7 +3,7 @@
 # Manually fetch and edit lwk repository
 
 REPO=https://github.com/Blockstream/lwk
-TAG=bindings_0.9.0
+TAG=wollet_0.18.0
 
 rm -rf rust_modules
 mkdir -p rust_modules

--- a/fetch_lwk.sh
+++ b/fetch_lwk.sh
@@ -3,7 +3,7 @@
 # Manually fetch and edit lwk repository
 
 REPO=https://github.com/Blockstream/lwk
-TAG=wollet_0.18.0
+TAG=bindings_0.18.0
 
 rm -rf rust_modules
 mkdir -p rust_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwk-rn",
-  "version": "0.18.0-2.0.0",
+  "version": "0.18.0",
   "description": "Liquid Wallet Kit react native module",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwk-rn",
-  "version": "0.9.0-2.0.3",
+  "version": "0.18.0-2.0.0",
   "description": "Liquid Wallet Kit react native module",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
@@ -206,6 +206,6 @@
     "version": "0.45.5"
   },
   "dependencies": {
-    "uniffi-bindgen-react-native": "^0.28.3-1"
+    "uniffi-bindgen-react-native": "^0.29.3-1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8607,7 +8607,7 @@ __metadata:
     release-it: ^17.10.0
     turbo: ^1.10.7
     typescript: ^5.2.2
-    uniffi-bindgen-react-native: ^0.28.3-1
+    uniffi-bindgen-react-native: ^0.29.3-1
   peerDependencies:
     react: "*"
     react-native: "*"
@@ -12439,13 +12439,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uniffi-bindgen-react-native@npm:^0.28.3-1":
-  version: 0.28.3-3
-  resolution: "uniffi-bindgen-react-native@npm:0.28.3-3"
+"uniffi-bindgen-react-native@npm:^0.29.3-1":
+  version: 0.29.3-1
+  resolution: "uniffi-bindgen-react-native@npm:0.29.3-1"
   bin:
     ubrn: bin/cli.cjs
     uniffi-bindgen-react-native: bin/cli.cjs
-  checksum: 743d91b1b51bca9bcd6af1e65cc8771846f3c28678c2e9cdf5f38f40a0e2fa31b406150ff5fc9b31d795c0b75159c41bd30119b016f90130cc8e0c11b37adcb7
+  checksum: 1cd0da57d11178823658c5e9a080570b65ec3f973ffac3c9ae131399681b5825727aa3ac397060e5e9aebe524194f9dddcd70acd14968d7c8f23f1bf66e7032b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump upstream LWK tag from `bindings_0.9.0` to `wollet_0.18.0` (lwk_bindings 0.18.0 ships under the `wollet_*` tag prefix).
- Bump `uniffi-bindgen-react-native` from `^0.28.3-1` to `^0.29.3-1`, required because LWK 0.18.0 depends on `uniffi = 0.29.4`.
- Bump package version to `0.18.0-2.0.0` and point the postinstall artifact fetch at the matching `0.18.0-2.0` release tag.

This PR only updates source/version refs. The generated bindings (`src/generated/*`, `cpp/generated/*`) and the platform artifact zips (`lwk-android-artifact.zip`, `lwk-ios-artifact.zip`) will be produced by the `generate.yml` workflow and a new `0.18.0-2.0` lwk-rn release.

## Test plan

- [ ] Run `.github/workflows/generate.yml` (workflow_dispatch) and confirm both Android and iOS artifact jobs succeed against `wollet_0.18.0`.
- [ ] Cut a `0.18.0-2.0` release on `Blockstream/lwk-rn` with both artifact zips so `fetch_artifacts.sh` resolves on `npm install`.
- [ ] Commit the regenerated `src/generated/*` and `cpp/generated/*` once produced; verify no manual edits required beyond regen.
- [ ] `yarn install`, `yarn typecheck`, `yarn lint`, `yarn test` pass on the branch with regenerated bindings.
- [ ] Confirm `example/src/App.tsx` still compiles against the new types (the reported `PsetBalance.fee` -> `fees` rename does not appear to affect this example, but verify after regen).
- [ ] Run the example on Android and iOS against testnet (`Network.testnet()`, `signer.wpkhSlip77Descriptor()`, `client.fullScan(wollet)`, `wollet.balance()`) to confirm runtime ABI matches.